### PR TITLE
Release: Add workflow for plugin release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,25 @@
+# Create release on change to plugin.info.txt version line
+# https://github.com/dokuwiki/dokuwiki/issues/3951
+#
+# Requires DOKUWIKI_USER and DOKUWIKI_PASS secrets be set in GitHub Actions
+
+name: Release
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "*.info.txt"
+
+jobs:
+  release:
+    name: Release
+    # https://github.com/dokuwiki/dokuwiki/pull/3966
+    uses: glensc/dokuwiki/.github/workflows/plugin-release.yml@8aaa80681ebaa642c4a8904ea2bf5cd8aff06243
+    secrets:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      DOKUWIKI_USER: ${{ secrets.DOKUWIKI_USER }}
+      DOKUWIKI_PASS: ${{ secrets.DOKUWIKI_PASS }}
+
+# vim:ft=yaml:et:ts=2:sw=2


### PR DESCRIPTION
Add automation for relasing:
- https://github.com/saggi-dw/dokuwiki-plugin-htmlok/issues/6

Uses:
- https://github.com/dokuwiki/dokuwiki/pull/3966

Requires `DOKUWIKI_USER` and `DOKUWIKI_PASS` secrets be set in GitHub Actions.

The flow is that you:
1. setup the secrets
2. merge this pr

if you modify plugin.info.txt and set new version, the action will make release with the value of `date` field.

Example release:
- https://github.com/glensc/dokuwiki-plugin-slacknotifier/releases/tag/2023-04-23
Example commit:
- https://github.com/glensc/dokuwiki-plugin-slacknotifier/commit/adcac4f3f5493a814dd05ceed6d26ca323a13ddc