### PR TITLE
Fix automated release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,8 +18,7 @@ jobs:
     # https://github.com/dokuwiki/dokuwiki/pull/3966
     uses: glensc/dokuwiki/.github/workflows/plugin-release.yml@39431875f734bddc35cc6b4a899bbfdec97e8aba
     secrets:
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       DOKUWIKI_USER: ${{ secrets.DOKUWIKI_USER }}
       DOKUWIKI_PASS: ${{ secrets.DOKUWIKI_PASS }}
 
-# vim:ft=yaml:et:ts=2:sw=2
+# vim:ts=2:sw=2:et

--- a/plugin.info.txt
+++ b/plugin.info.txt
@@ -1,7 +1,7 @@
 base   htmlok
 author saggi, glen
 email  saggi@gmx.de
-date   2023-05-10
+date   2024-01-11
 name   htmlok plugin
 desc   Allows embed HTML and PHP
 url    https://www.dokuwiki.org/plugin:htmlok


### PR DESCRIPTION
Update from:
- https://github.com/glensc/dokuwiki-plugin-slacknotifier/blob/1058714210b6c162c8845047732c363b4aa374a2/.github/workflows/release.yml

Resolves this error:

```
Invalid workflow file: .github/workflows/release.yml#L21
The workflow is not valid. .github/workflows/release.yml (Line: 21, Col: 21): Invalid secret, GITHUB_TOKEN is not defined in the referenced workflow.
```

- https://github.com/saggi-dw/dokuwiki-plugin-htmlok/actions/runs/4955847601

Refs:
- https://github.com/saggi-dw/dokuwiki-plugin-htmlok/pull/11#issuecomment-1886670255

Fixes:
- https://github.com/saggi-dw/dokuwiki-plugin-htmlok/issues/6